### PR TITLE
Fix wordpress path issue

### DIFF
--- a/vpos-checkout.php
+++ b/vpos-checkout.php
@@ -641,7 +641,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
 
     function completeOrder() {
       const orderId = <?php echo $_COOKIE['vpos_order_id']; ?>;
-      return axios.get("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php?order_id=" + orderId + "&type=complete-order",
+      return axios.get("/wp-content/plugins/vpos-woocommerce/handle.php?order_id=" + orderId + "&type=complete-order",
       {validateStatus: (status => status < 300)})
       .then(function (response) {
         document.getElementById("url").innerText = "Ir para o sumário da compra"
@@ -656,7 +656,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
     }
 
     function get(id) {
-      return axios.get("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=get",
+      return axios.get("/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=get",
       {validateStatus: (status => status < 400)})
       .then(function (response) {
         if (response.status == 200) {
@@ -693,7 +693,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
     }
 
     function poll(id) {
-      return axios.get("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=poll"
+      return axios.get("/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=poll"
       ,{validateStatus: (status) => status < 400 })
       .then(function (response) {
           this.state = "processing";
@@ -713,7 +713,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
       var form = new FormData();
       form.append('mobile', mobile_no_prefix);
       form.append('amount', parseFloat(amount));
-      return axios.post("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php", 
+      return axios.post("/wp-content/plugins/vpos-woocommerce/handle.php", 
        form,
       headers)
       .then(response => {


### PR DESCRIPTION
This PR fixes the problem that caused a 404 when a customer tries to perform a payment.

The problem occurs because all http requests are routed to handle.php which is in the `vpos-woocommerce` folder.
Unfortunately the file `vpos-checkout.php` expects the location of the file to be inside a root folder called `wordpress` of the server running the wordpress application, which is not the usual place where wordpress is installed.

Often times, wordpress is installed in /var/www/html and not /var/www/html/wordpress.

How to fix?

We change vpos-checkout.php to point to a more general wp-content inside the root folder instead, since most installations of wordpress follow this configuration.