### PR TITLE
FIX: Transactions Failed

### DIFF
--- a/src/controllers/vpos_controller.php
+++ b/src/controllers/vpos_controller.php
@@ -223,12 +223,12 @@ class VposController extends WP_REST_Controller
         
         $order = wc_get_order($result->order_id);
         
-        if ($order->is_paid() || $order->has_status("processing") || $order->has_status("completed") || $order->has_status("failed")) {
-            return new WP_REST_Response(null, 201);
+        if ($order->is_paid() || $order->has_status("processing") || $order->has_status("completed")) {
+            return new WP_REST_Response(null, 200);
         }
 
         if ($result->status == "accepted" && $result->status == "rejected") {
-            return new WP_REST_Response(null, 201);
+            return new WP_REST_Response(null, 202);
         }
 
         if ($body->{"status"} == "accepted") {

--- a/vpos-checkout.php
+++ b/vpos-checkout.php
@@ -684,7 +684,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
     }
 
     function sendPaymentRequest(amount, mobile) {
-        //document.getElementById("submit").disabled = true
+      document.getElementById("submit").disabled = true
       return axios.post(payments_url, {
         mobile: mobile,
         amount: amount


### PR DESCRIPTION
This pr resolves the problem that was not updating transactions when the order status is failed.
When cart order was previously created and the status is failed the handle confirmation method was not updating the order status with the vPOS response because of a business logic error that was assuming failed orders could be reprocessed.